### PR TITLE
Full Name Attributes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,7 @@ import CharacterDialog from '@/components/CharacterDialog';
 
 import { useCharacterStore } from '@/data/characterStore';
 
-import attributes from '@/utils/attributeUtils';
+import attributes, { shorthandByAttribute } from '@/utils/attributeUtils';
 import { applyLevelUpToLevel, getBaseLevel } from '@/utils/levelUtils';
 
 export default function Home() {
@@ -123,10 +123,14 @@ export default function Home() {
             className="sticky top-0 z-10 grid w-full max-w-7xl grid-cols-[3rem_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] place-items-center bg-inherit shadow-lg sm:grid-cols-[5rem_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] xl:grid-cols-[5rem_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr]"
             style={{ gridAutoRows: 'minmax(3rem, auto)' }}
           >
-            <div className="sm:text-lg">LVL</div>
+            <div className="sm:text-lg">
+              <span className="inline lg:hidden">LVL</span>
+              <span className="hidden lg:inline">Level</span>
+            </div>
             {attributes.map((attribute) => (
               <div className="sm:text-lg" key={attribute}>
-                {attribute}
+                <span className="inline lg:hidden">{shorthandByAttribute[attribute]}</span>
+                <span className="hidden lg:inline">{attribute}</span>
               </div>
             ))}
             <div className="px0 hidden xl:block">Health</div>

--- a/src/components/CharacterDialog.tsx
+++ b/src/components/CharacterDialog.tsx
@@ -25,7 +25,11 @@ import DropDown from '@/components/DropDown';
 
 import { useCharacterStore } from '@/data/characterStore';
 
-import attributes, { skillsByAttribute, NUM_FAVORED_ATTRIBUTES } from '@/utils/attributeUtils';
+import attributes, {
+  skillsByAttribute,
+  NUM_FAVORED_ATTRIBUTES,
+  shorthandByAttribute,
+} from '@/utils/attributeUtils';
 import specializations from '@/utils/specializationUtils';
 import races from '@/utils/raceUtils';
 import genders from '@/utils/genderUtils';
@@ -138,13 +142,16 @@ export default function CharacterDialog(props: {
           }
         />
         <div className="mt-6 text-xs">Choose 2 favored attributes and 7 major skills</div>
-        <div className="my-4 grid grid-cols-[3rem_1fr_3fr] place-items-center">
+        <div className="my-4 grid grid-cols-[3rem_1fr_3fr] place-items-center lg:grid-cols-[6rem_1fr_3fr]">
           <div></div>
           <div className="text-lg">Favored</div>
           <div className="text-lg">Skills</div>
           {attributes.map((attribute) => (
             <React.Fragment key={attribute}>
-              <div>{attribute}</div>
+              <div className="mt-1 w-full text-right">
+                <span className="inline lg:hidden">{shorthandByAttribute[attribute]}</span>
+                <span className="hidden lg:inline">{attribute}</span>
+              </div>
               <Checkbox
                 checked={favoredAttributes.includes(attribute)}
                 onChange={() => {

--- a/src/utils/attributeUtils.ts
+++ b/src/utils/attributeUtils.ts
@@ -1,6 +1,15 @@
 import type { Skill } from '@/utils/skillUtils';
 
-export type Attribute = 'STR' | 'INT' | 'WIL' | 'AGL' | 'SPD' | 'END' | 'PER' | 'LCK';
+export type Attribute =
+  | 'Strength'
+  | 'Intelligence'
+  | 'Willpower'
+  | 'Agility'
+  | 'Speed'
+  | 'Endurance'
+  | 'Personality'
+  | 'Luck';
+export type AttributeShorthand = 'STR' | 'INT' | 'WIL' | 'AGL' | 'SPD' | 'END' | 'PER' | 'LCK';
 
 export type AttributesModifier = Partial<AttributesSet>;
 
@@ -12,47 +21,47 @@ export const MAX_ATTRIBUTE_LEVEL = 100;
 export const SKILL_UPS_FOR_MAX_ATTRIBUTE_BONUS = 10;
 
 export const maxBonusByAttribute: AttributesSet = {
-  STR: 5,
-  INT: 5,
-  WIL: 5,
-  AGL: 5,
-  SPD: 5,
-  END: 5,
-  PER: 5,
-  LCK: 1,
+  Strength: 5,
+  Intelligence: 5,
+  Willpower: 5,
+  Agility: 5,
+  Speed: 5,
+  Endurance: 5,
+  Personality: 5,
+  Luck: 1,
 };
 
 export const baseAttributes: AttributesSet = {
-  STR: 40,
-  INT: 40,
-  WIL: 40,
-  AGL: 40,
-  SPD: 40,
-  END: 40,
-  PER: 40,
-  LCK: 50,
+  Strength: 40,
+  Intelligence: 40,
+  Willpower: 40,
+  Agility: 40,
+  Speed: 40,
+  Endurance: 40,
+  Personality: 40,
+  Luck: 50,
 };
 
 export const getAttributesSetTemplate: () => AttributesSet = () => ({
-  STR: 0,
-  INT: 0,
-  WIL: 0,
-  AGL: 0,
-  SPD: 0,
-  END: 0,
-  PER: 0,
-  LCK: 0,
+  Strength: 0,
+  Intelligence: 0,
+  Willpower: 0,
+  Agility: 0,
+  Speed: 0,
+  Endurance: 0,
+  Personality: 0,
+  Luck: 0,
 });
 
 export const skillsByAttribute: { [key in Attribute]: Skill[] } = {
-  STR: ['Blade', 'Blunt', 'Hand-to-Hand'],
-  INT: ['Alchemy', 'Conjuration', 'Mysticism'],
-  WIL: ['Alteration', 'Destruction', 'Restoration'],
-  AGL: ['Security', 'Sneak', 'Marksmanship'],
-  SPD: ['Athletics', 'Acrobatics', 'Light Armor'],
-  END: ['Armorer', 'Block', 'Heavy Armor'],
-  PER: ['Mercantile', 'Speechcraft', 'Illusion'],
-  LCK: [],
+  Strength: ['Blade', 'Blunt', 'Hand-to-Hand'],
+  Intelligence: ['Alchemy', 'Conjuration', 'Mysticism'],
+  Willpower: ['Alteration', 'Destruction', 'Restoration'],
+  Agility: ['Security', 'Sneak', 'Marksmanship'],
+  Speed: ['Athletics', 'Acrobatics', 'Light Armor'],
+  Endurance: ['Armorer', 'Block', 'Heavy Armor'],
+  Personality: ['Mercantile', 'Speechcraft', 'Illusion'],
+  Luck: [],
 };
 
 export const getAttributeFromSkill = (skill: Skill): Attribute => {
@@ -82,7 +91,27 @@ export function getAttributeBonusFromSkillUps(attributeLevel: number, numSkillUp
   return Math.max(0, Math.min(remainingLevels, bonus));
 }
 
-const attributes: Attribute[] = ['STR', 'INT', 'WIL', 'AGL', 'SPD', 'END', 'PER', 'LCK'];
+const attributes: Attribute[] = [
+  'Strength',
+  'Intelligence',
+  'Willpower',
+  'Agility',
+  'Speed',
+  'Endurance',
+  'Personality',
+  'Luck',
+];
+
+export const shorthandByAttribute: { [key in Attribute]: AttributeShorthand } = {
+  Strength: 'STR',
+  Intelligence: 'INT',
+  Willpower: 'WIL',
+  Agility: 'AGL',
+  Speed: 'SPD',
+  Endurance: 'END',
+  Personality: 'PER',
+  Luck: 'LCK',
+};
 
 export const NUM_FAVORED_ATTRIBUTES = 2;
 


### PR DESCRIPTION
## Description

Show full name of attributes at larger resolutions.
Applies to main page, and character creation dialog.

## Notes

This will break localstorage's state, as we're now keying on attribute fullnames, rather than their shorthand