### PR TITLE
Fix - Docker Exposed Ports

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,6 +3,6 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install
 COPY . .
-EXPOSE $PORT
+EXPOSE 3000
 
 CMD ["npm", "run", "dev"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -4,7 +4,7 @@ COPY package.json ./
 RUN npm install
 COPY . .
 RUN npm run build
-EXPOSE $PORT
+EXPOSE 3000
 
 CMD ["npm", "start"]
 


### PR DESCRIPTION
## Description

The Dockerfile's EXPOSE values were incorrect. They should be hardcoded to the internally used port.